### PR TITLE
[CS-40124] Private script to backfill EBT cards in Credit table with card_product_type

### DIFF
--- a/scripts/ebt_backfills.rb
+++ b/scripts/ebt_backfills.rb
@@ -1,0 +1,51 @@
+batch_size = 10 #TODO: change this based on progress
+sleep_time = 1
+num_batches = 10 #TODO: change this
+
+fails = []
+while fails.size == 0 and num_batches > 0
+	# Fetch last few records
+	ebt_cards = Credit.where(card_product_type: nil)
+		.where(credit_card_type: "EBT")
+		.last(batch_size)
+
+	ebt_cards.each do |card|
+        begin
+			card.card_product_type = 3
+			card.save!
+		rescue => e
+			fails << {card: card, error: e}
+		end
+	end
+
+	# Avoid hitting DB too hard
+	sleep sleep_time
+	num_batches -= 1
+end
+
+if fails.size > 0
+	puts "Error occur:"
+	fails.each |fail_item|
+		puts fail_item
+	end
+end
+
+
+
+
+
+
+
+
+[
+  [0] 71823173,
+  [1] 71823181,
+  [2] 71823221,
+  [3] 71823233,
+  [4] 71823243,
+  [5] 71823248,
+  [6] 71823511,
+  [7] 71823513,
+  [8] 71830972,
+  [9] 71831036
+]

--- a/scripts/ebt_backfills.rb
+++ b/scripts/ebt_backfills.rb
@@ -3,49 +3,29 @@ sleep_time = 1
 num_batches = 10 #TODO: change this
 
 fails = []
-while fails.size == 0 and num_batches > 0
-	# Fetch last few records
-	ebt_cards = Credit.where(card_product_type: nil)
-		.where(credit_card_type: "EBT")
-		.last(batch_size)
+while fails.size.zero? and num_batches.positive?
+  # Fetch last few records
+  ebt_cards = Credit.where(card_product_type: nil)
+    .where(credit_card_type: 'EBT')
+    .last(batch_size)
 
-	ebt_cards.each do |card|
-        begin
-			card.card_product_type = 3
-			card.save!
-		rescue => e
-			fails << {card: card, error: e}
-		end
-	end
+  ebt_cards.each do |card|
+    begin
+      card.card_product_type = 3
+      card.save!
+    rescue => e
+      fails << { card: card, error: e }
+    end
+  end
 
-	# Avoid hitting DB too hard
-	sleep sleep_time
-	num_batches -= 1
+  # Avoid hitting DB too hard
+  sleep sleep_time
+  num_batches -= 1
 end
 
-if fails.size > 0
-	puts "Error occur:"
-	fails.each |fail_item|
-		puts fail_item
-	end
+if fails.size.positive?
+  puts 'Error occur during backfill:'
+  fails.each do |fail_item|
+    puts fail_item
+  end
 end
-
-
-
-
-
-
-
-
-[
-  [0] 71823173,
-  [1] 71823181,
-  [2] 71823221,
-  [3] 71823233,
-  [4] 71823243,
-  [5] 71823248,
-  [6] 71823511,
-  [7] 71823513,
-  [8] 71830972,
-  [9] 71831036
-]


### PR DESCRIPTION
Note this script is in private repo, planed to be used with "isc console". 

The purpose is to use it to backfill EBT cards in Credit table. Break the execution in batches, there are a number of items in each batch. If there is any failure in a batch, the execution flow terminates and print out exception.

